### PR TITLE
fix: advanced-search page

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -336,7 +336,7 @@ export class PicaComicAPI {
           keyword: payload.keyword,
           categories: payload.categories,
           s: payload.sort || 'ua'
-        },
+        }
       })
       .json<Response<{ comics: types.Comics }>>()
       .then(res => res.data.comics)

--- a/src/api.ts
+++ b/src/api.ts
@@ -331,12 +331,12 @@ export class PicaComicAPI {
     return this.fetch
       .post('comics/advanced-search', {
         headers: makeAuthorizationHeaders(payload.token),
+        searchParams: { page: payload.page || 1 },
         json: {
           keyword: payload.keyword,
           categories: payload.categories,
-          page: payload.page || 1,
           s: payload.sort || 'ua'
-        }
+        },
       })
       .json<Response<{ comics: types.Comics }>>()
       .then(res => res.data.comics)


### PR DESCRIPTION
the `page` parameter should use `searchParams` in search method